### PR TITLE
feat: allow custom download options

### DIFF
--- a/download_upstream.py
+++ b/download_upstream.py
@@ -32,6 +32,9 @@ if __name__ == '__main__':
     parser.add_argument('--skip_bbox_blurring', help='If true, skip bounding box blurring on images while downloading.', action='store_true', default=False)
     parser.add_argument('--processes_count', type=int, required=False, default=16, help='Number of processes for download.')
     parser.add_argument('--thread_count', type=int, required=False, default=128, help='Number of threads for download.')
+    parser.add_argument('--image_size', type=int, required=False, default=512, help='Size images need to be downloaded to.')
+    parser.add_argument('--resize_mode', type=str, required=False, choices=["no", "border", "keep_ratio", "keep_ratio_largest", "center_crop"], default='keep_ratio_largest', help='Resizing mode used by img2dataset when downloading images.')
+    parser.add_argument('--output_format', type=str, required=False, choices=["webdataset", "tfrecord", "parquet", "files"], default='webdataset', help='Output format used by img2dataset when downloading images.')
     
     args = parser.parse_args()
 
@@ -113,13 +116,13 @@ if __name__ == '__main__':
 
     img2dataset.download(
         url_list=str(metadata_dir),
-        image_size=512,
+        image_size=args.image_size,
         output_folder=str(shard_dir),
         processes_count=args.processes_count,
         thread_count=args.thread_count,
-        resize_mode='keep_ratio_largest',
-        resize_only_if_bigger=True,
-        output_format='webdataset',
+        resize_mode=args.resize_mode,
+        resize_only_if_bigger=False,
+        output_format=args.output_format,
         input_format='parquet',
         url_col='url',
         caption_col='text',


### PR DESCRIPTION
Allow custom options for downloading dataset:
- image_size
- resize_mode
- resize_only_if_bigger
- output_format

The use case is to train CLIP models in JAX on TPU's:
- format needs to be tfrecords
- all images need to have same size

What is nice is that the `small` pool can fit on a singe TPU v3-8 with all images resized to 256.

**BREAKING CHANGE**

- We would require using `resize_only_if_bigger` to keep same default as before. We could also use a different arg such as `no_resize_only_if_bigger`