### PR TITLE
Remove symlinks from download_upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,17 @@ There are four scales in our competition:
 - `xlarge`: 12.8B pool size, 12.8B examples seen
 
 
+The script will create two directories inside `$data_dir`: `metadata/$scale` and `shards/$scale`. 
 
-Along with the images and captions, this script will also download metadata, including `.parquet` files that contain the image urls, captions, and other potentially useful information such as the similarities between the images and captions given by trained OpenAI CLIP models. 
-If the flag `--download_npz` is used, the script will also download the `.npz` files with features extracted by the trained OpenAI CLIP models for each sample. 
+The metadata directory includes `.parquet` files that contain the 
+image urls, captions, and other potentially useful information such as the similarities between the images and captions given by trained OpenAI CLIP models. 
+If the flag `--download_npz` is used, the script will also download to `.npz` files to the metadata directory. 
+They contain features extracted by the trained OpenAI CLIP models for each sample. We download the metadata from the HuggingFace hub.
 
-The data is stored in shards, which are `tar` files with the images and captions to be consumed by [webdataset](https://github.com/webdataset/webdataset/).
-Once the download finishes, the data will be available at `$data_dir/shards`.
+We download the image data using [img2dataset](https://github.com/rom1504/img2dataset), which stores it as `.tar` shards with the images and captions to be consumed by [webdataset](https://github.com/webdataset/webdataset/).
+Once the download finishes, the data will be available at `$data_dir/shards/$scale`.
+
+To download only metadata, use the `--skip_shards` flag.
 
 The disk requirements for each scale are shown below.
 
@@ -68,12 +73,6 @@ The disk requirements for each scale are shown below.
 | `xlarge` scale  |        3 TB         |      75TB       |    450 TB   |
 
 
-
-### Downloading external data
-
-The script `download_upstream.py` can also be used to download other image-text datasets, using [img2dataset](https://github.com/rom1504/img2dataset).
-Given parquet files containing the image urls and captions, you can use this script to download the images, by using the flag `--metadata_dir` to point to the directory where the parquet files are stored.
-By default, we also download the parquet files corresponding to the pools we provide, and this metadata is stored in a subfolder of `$data_dir`. 
 
 
 ## Selecting samples in the filtering track

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There are four scales in our competition:
 - `xlarge`: 12.8B pool size, 12.8B examples seen
 
 
-The script will create two directories inside `$data_dir`: `metadata/$scale` and `shards/$scale`. 
+The script will create two directories inside `$data_dir`: `metadata` and `shards`. 
 
 The metadata directory includes `.parquet` files that contain the 
 image urls, captions, and other potentially useful information such as the similarities between the images and captions given by trained OpenAI CLIP models. 
@@ -59,7 +59,7 @@ If the flag `--download_npz` is used, the script will also download to `.npz` fi
 They contain features extracted by the trained OpenAI CLIP models for each sample. We download the metadata from the HuggingFace hub.
 
 We download the image data using [img2dataset](https://github.com/rom1504/img2dataset), which stores it as `.tar` shards with the images and captions to be consumed by [webdataset](https://github.com/webdataset/webdataset/).
-Once the download finishes, the data will be available at `$data_dir/shards/$scale`.
+Once the download finishes, the data will be available at `$data_dir/shards`.
 
 To download only metadata, use the `--skip_shards` flag.
 

--- a/download_upstream.py
+++ b/download_upstream.py
@@ -73,7 +73,6 @@ if __name__ == '__main__':
 
     if not args.skip_shards:
         # Download images.
-        metadata_dir = metadata_dir / f'{args.scale}'
         shard_dir = args.data_dir / 'shards' / f'{args.scale}'
         shard_dir.mkdir(parents=True, exist_ok=True)
         print(f'Downloading images to {shard_dir}')

--- a/download_upstream.py
+++ b/download_upstream.py
@@ -28,21 +28,19 @@ if __name__ == '__main__':
     parser.add_argument('--data_dir', type=path_or_cloudpath, required=True, help='Path to directory where the data (webdataset shards) will be stored.')
     parser.add_argument('--metadata_dir', type=path_or_cloudpath, default=None, help='Path to directory where the metadata will be stored. If not set, infer from data_dir.')
     parser.add_argument('--download_npz', help='If true, also download npz files.', action='store_true', default=False)
+    parser.add_argument('--skip_shards', help='If true, only download metadata.', action='store_true', default=False)
     parser.add_argument('--overwrite_metadata', help='If true, force re-download of the metadata files.', action='store_true', default=False)
     parser.add_argument('--skip_bbox_blurring', help='If true, skip bounding box blurring on images while downloading.', action='store_true', default=False)
     parser.add_argument('--processes_count', type=int, required=False, default=16, help='Number of processes for download.')
     parser.add_argument('--thread_count', type=int, required=False, default=128, help='Number of threads for download.')
-    parser.add_argument('--image_size', type=int, required=False, default=512, help='Size images need to be downloaded to.')
-    parser.add_argument('--resize_mode', type=str, required=False, choices=["no", "border", "keep_ratio", "keep_ratio_largest", "center_crop"], default='keep_ratio_largest', help='Resizing mode used by img2dataset when downloading images.')
-    parser.add_argument('--no_resize_only_if_bigger', help='If true, do not resize only if images are bigger than target size.', action='store_true', default=False)
-    parser.add_argument('--encode_format', type=str, required=False, choices=["png", "jpg", "webp"], default='jpg', help='Images encoding format.')
-    parser.add_argument('--output_format', type=str, required=False, choices=["webdataset", "tfrecord", "parquet", "files"], default='webdataset', help='Output format used by img2dataset when downloading images.')
     
     args = parser.parse_args()
 
     metadata_dir = args.metadata_dir
     if metadata_dir is None:
         metadata_dir = args.data_dir / 'metadata'
+    if metadata_dir.parts[-1] != args.scale:
+        metadata_dir = metadata_dir / f'{args.scale}'
 
     # Download the metadata files if needed.
     if args.overwrite_metadata or not metadata_dir.exists():
@@ -53,87 +51,54 @@ if __name__ == '__main__':
 
         print(f'Downloading metadata to {metadata_dir}...')
 
-        if args.scale != 'xlarge':
-            hf_metadata_dir = snapshot_download(
-                repo_id=HF_REPO,
-                allow_patterns=f'{args.scale}/*.parquet',
-                cache_dir=metadata_dir / 'hf',
-                repo_type='dataset'
-            )
-            if args.download_npz:
-                print('Downloading npz files')
-                snapshot_download(
-                    repo_id=HF_REPO,
-                    allow_patterns=f'{args.scale}/*.npz',
-                    cache_dir=metadata_dir / 'hf',
-                    repo_type='dataset'
-                )
-        else:
-            # Slightly different handling for xlarge scale
-            hf_metadata_dir = snapshot_download(
-                repo_id=HF_REPO,
-                allow_patterns=f'{args.scale}/*/*.parquet',
-                cache_dir=metadata_dir / 'hf',
-                repo_type='dataset'
-            )
-            if args.download_npz:
-                print('Downloading npz files')
-                npz_hf_metadata_dir = snapshot_download(
-                    repo_id=HF_REPO,
-                    allow_patterns=f'{args.scale}_npzs/*/*.npz',
-                    cache_dir=metadata_dir / 'hf',
-                    repo_type='dataset'
-                )
+        hf_snapshot_args = dict(repo_id=HF_REPO,
+                                allow_patterns=f'{args.scale}/*.parquet',
+                                local_dir=metadata_dir.parent,
+                                cache_dir=metadata_dir.parent / 'hf',
+                                local_dir_use_symlinks=False,
+                                repo_type='dataset')
 
-        # Create symlinks
-        hf_metadata_dir = Path(hf_metadata_dir) / f'{args.scale}'
-        for filename in hf_metadata_dir.rglob('*.parquet'):
-            link_filename = metadata_dir / filename.name
-            true_filename = filename.resolve()
-            link_filename.symlink_to(true_filename)
+        if args.scale == 'xlarge':
+            hf_snapshot_args['allow_patterns'] = f'{args.scale}/*/*.parquet'
 
+        snapshot_download(**hf_snapshot_args)
         if args.download_npz:
-            if args.scale != 'xlarge':
-                for filename in hf_metadata_dir.rglob('*.npz'):
-                    link_filename = metadata_dir / filename.name
-                    true_filename = filename.resolve()
-                    link_filename.symlink_to(true_filename)
-            else:
-                npz_hf_metadata_dir = Path(npz_hf_metadata_dir) / f'{args.scale}_npzs'
-                for filename in npz_hf_metadata_dir.rglob('*.npz'):
-                    link_filename = metadata_dir / filename.name
-                    true_filename = filename.resolve()
-                    link_filename.symlink_to(true_filename)
+            hf_snapshot_args['allow_patterns'] = hf_snapshot_args['allow_patterns'].replace('.parquet', '.npz')
+            print('\nDownloading npz files')
+            snapshot_download(**hf_snapshot_args)
 
         print('Done downloading metadata.')
     else:
         print(f'Skipping download of metadata because {metadata_dir} exists. Use --overwrite_metadata to force re-downloading.')
 
-    # Download images.
-    shard_dir = args.data_dir / 'shards'
-    shard_dir.mkdir(parents=True, exist_ok=True)
-    print(f'Downloading images to {shard_dir}')
+    if not args.skip_shards:
+        # Download images.
+        metadata_dir = metadata_dir / f'{args.scale}'
+        shard_dir = args.data_dir / 'shards' / f'{args.scale}'
+        shard_dir.mkdir(parents=True, exist_ok=True)
+        print(f'Downloading images to {shard_dir}')
 
-    bbox_col = None if args.skip_bbox_blurring else 'face_bboxes'
+        bbox_col = None if args.skip_bbox_blurring else 'face_bboxes'
 
-    img2dataset.download(
-        url_list=str(metadata_dir),
-        image_size=args.image_size,
-        output_folder=str(shard_dir),
-        processes_count=args.processes_count,
-        thread_count=args.thread_count,
-        resize_mode=args.resize_mode,
-        resize_only_if_bigger=not args.no_resize_only_if_bigger,
-        encode_format=args.encode_format,
-        output_format=args.output_format,
-        input_format='parquet',
-        url_col='url',
-        caption_col='text',
-        bbox_col=bbox_col,
-        save_additional_columns=['uid'],
-        number_sample_per_shard=10000,
-        oom_shard_count=8
-    )
+        img2dataset.download(
+            url_list=str(metadata_dir),
+            image_size=512,
+            output_folder=str(shard_dir),
+            processes_count=args.processes_count,
+            thread_count=args.thread_count,
+            resize_mode='keep_ratio_largest',
+            resize_only_if_bigger=True,
+            output_format='webdataset',
+            input_format='parquet',
+            url_col='url',
+            caption_col='text',
+            bbox_col=bbox_col,
+            save_additional_columns=['uid'],
+            number_sample_per_shard=10000,
+            oom_shard_count=8
+        )
+    else:
+        print(f'Skipping image data download.')
 
     print('Done!')
     

--- a/download_upstream.py
+++ b/download_upstream.py
@@ -33,7 +33,12 @@ if __name__ == '__main__':
     parser.add_argument('--skip_bbox_blurring', help='If true, skip bounding box blurring on images while downloading.', action='store_true', default=False)
     parser.add_argument('--processes_count', type=int, required=False, default=16, help='Number of processes for download.')
     parser.add_argument('--thread_count', type=int, required=False, default=128, help='Number of threads for download.')
-    
+    parser.add_argument('--image_size', type=int, required=False, default=512, help='Size images need to be downloaded to.')
+    parser.add_argument('--resize_mode', type=str, required=False, choices=["no", "border", "keep_ratio", "keep_ratio_largest", "center_crop"], default='keep_ratio_largest', help='Resizing mode used by img2dataset when downloading images.')
+    parser.add_argument('--no_resize_only_if_bigger', help='If true, do not resize only if images are bigger than target size.', action='store_true', default=False)
+    parser.add_argument('--encode_format', type=str, required=False, choices=["png", "jpg", "webp"], default='jpg', help='Images encoding format.')
+    parser.add_argument('--output_format', type=str, required=False, choices=["webdataset", "tfrecord", "parquet", "files"], default='webdataset', help='Output format used by img2dataset when downloading images.')
+
     args = parser.parse_args()
 
     metadata_dir = args.metadata_dir
@@ -73,6 +78,7 @@ if __name__ == '__main__':
 
     if not args.skip_shards:
         # Download images.
+        metadata_dir = metadata_dir / f'{args.scale}'
         shard_dir = args.data_dir / 'shards' / f'{args.scale}'
         shard_dir.mkdir(parents=True, exist_ok=True)
         print(f'Downloading images to {shard_dir}')
@@ -81,13 +87,14 @@ if __name__ == '__main__':
 
         img2dataset.download(
             url_list=str(metadata_dir),
-            image_size=512,
+            image_size=args.image_size,
             output_folder=str(shard_dir),
             processes_count=args.processes_count,
             thread_count=args.thread_count,
-            resize_mode='keep_ratio_largest',
-            resize_only_if_bigger=True,
-            output_format='webdataset',
+            resize_mode=args.resize_mode,
+            resize_only_if_bigger=not args.no_resize_only_if_bigger,
+            encode_format=args.encode_format,
+            output_format=args.output_format,
             input_format='parquet',
             url_col='url',
             caption_col='text',

--- a/environment.yml
+++ b/environment.yml
@@ -82,7 +82,7 @@ dependencies:
       - googleapis-common-protos==1.57.0
       - grpcio==1.50.0
       - h5py==3.7.0
-      - huggingface-hub==0.11.0
+      - huggingface-hub==0.14.1
       - idna==3.4
       - imageio==2.22.4
       - img2dataset==1.40.0


### PR DESCRIPTION
The current implementation of `download_upstream.py` creates symlinks that may be relative or absolute depending on how data_dir is input. The relative symlinks don't play nice with the baselines code, and one can imagine absolute symlinks causing problems as well. 

This PR removes the symlinks by using an appropriate argument to the HF `snapshot_download`. 

As a byproduct, the name of the scale gets added to the download folder - I have updated readme.md accordingly, but we should check it doesn't break anything else down the line.