### PR TITLE
Updated img2dataset to pull from the Spawning-Inc fork

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -85,7 +85,7 @@ dependencies:
       - huggingface-hub==0.14.1
       - idna==3.4
       - imageio==2.22.4
-      - img2dataset==1.40.0
+      - img2dataset @ https://github.com/Spawning-Inc/img2dataset/archive/refs/heads/main.tar.gz
       - importlib-resources==5.10.0
       - isodate==0.6.1
       - jmespath==1.0.1

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -76,10 +76,10 @@ dependencies:
       - googleapis-common-protos==1.57.0
       - grpcio==1.50.0
       - h5py==3.7.0
-      - huggingface-hub==0.11.0
+      - huggingface-hub==0.14.1
       - idna==3.4
       - imageio==2.22.4
-      - img2dataset==1.40.0
+      - img2dataset @ https://github.com/Spawning-Inc/img2dataset/archive/refs/heads/main.tar.gz
       - importlib-resources==5.10.0
       - isodate==0.6.1
       - jmespath==1.0.1


### PR DESCRIPTION
This PR replaces the `img2dataset` dependency with a fork that includes the [datadiligence](https://datadiligence.readthedocs.io/en/latest/readme.html) python package, which makes it easy to respect opt-out requests. There is an unmerged [PR](https://github.com/rom1504/img2dataset/pull/312) in the main img2dataset repository which includes these changes.

How datadiligence can improve the quality of datacomp submissions:
1. **Machine-readable opt-outs and EU TDM Article 4.** 
Spawning is working with the EU Copyright office to make it easy for researchers to comply with opt-out requirements for commercial models. Respecting these methods now increases the likelihood that submissions released with commercially-friendly licenses can be used in the future.

2. **Ignoring the wishes of site owners can provoke antagonistic responses.** 
With over 12 billion images, the potential for new and noticeably large amounts of automated traffic to sites and services is high. This traffic comes with costs - it increases expenses for site owners over the lifetime of the dataset (see[ ttps://www.vice.com/en/article/dy3vmx/an-ai-scraping-tool-is-overwhelming-websites-with-traffic](https://www.vice.com/en/article/dy3vmx/an-ai-scraping-tool-is-overwhelming-websites-with-traffic) and[ https://github.com/rom1504/img2dataset/issues/293](https://github.com/rom1504/img2dataset/issues/293)). 
\
If left unchecked, this traffic will likely inspire defensive and antagonistic responses similar to DDoS mitigation. By respecting opted-out domains, we can lower the risk of provoking these responses, thus maintaining the quality of the datacomp dataset over a longer period of time.

3. **The Spawning API does more than just filter opt-outs.** 
The Spawning API also filters URLs from unsafe domains (phishing, malware, spam, etc). The content on these domains is not only likely low-quality, but also dangerous. 


The datadiligence package is easy to incorporate and requires no change to existing workflows. In fact, img2dataset already respects one opt-out method by default. Datadiligence includes that method, other proposed standards (eg [TDMRep](https://www.w3.org/2022/tdmrep/)), and will continue to incorporate new methods as they become adopted.

The goal of this competition is to curate a high-quality dataset, and we believe the datadiligence package can contribute.

This PR also includes a small bug fix for a recently introduced bug for macOS. The recent change in the huggingface-hub dependency appears to not have been made in the `environment_osx.yml` file.