### PR TITLE
Update environment_osx.yml

### DIFF
--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -76,7 +76,7 @@ dependencies:
       - googleapis-common-protos==1.57.0
       - grpcio==1.50.0
       - h5py==3.7.0
-      - huggingface-hub==0.11.0
+      - huggingface-hub==0.14.1
       - idna==3.4
       - imageio==2.22.4
       - img2dataset==1.40.0


### PR DESCRIPTION
Correct `huggingface-hub` version for `environment_osx.yml` to resolve a kwarg issue affecting OSX system users. Now `environment_osx.yml` and `environment.yml` should have the same `huggingface-hub` version.