### PR TITLE
Add AWS S3 dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -45,6 +45,7 @@ dependencies:
       - click==8.1.3
       - clip-benchmark==1.4.0
       - cloudpathlib==0.13.0
+      - cloudpathlib[s3]==0.13.0
       - colorama==0.4.4
       - contourpy==1.0.7
       - cryptography==39.0.2
@@ -145,6 +146,7 @@ dependencies:
       - requests-oauthlib==1.3.1
       - responses==0.18.0
       - rsa==4.7.2
+      - s3fs==2022.11.0
       - scikit-image==0.19.3
       - scikit-learn==1.1.3
       - scipy==1.9.3

--- a/environment_osx.yml
+++ b/environment_osx.yml
@@ -39,6 +39,7 @@ dependencies:
       - click==8.1.3
       - clip-benchmark==1.4.0
       - cloudpathlib==0.13.0
+      - cloudpathlib[s3]==0.13.0
       - colorama==0.4.4
       - contourpy==1.0.7
       - cryptography==39.0.2
@@ -135,6 +136,7 @@ dependencies:
       - requests-oauthlib==1.3.1
       - responses==0.18.0
       - rsa==4.7.2
+      - s3fs==2022.11.0
       - scikit-image==0.19.3
       - scikit-learn==1.1.3
       - scipy==1.9.3


### PR DESCRIPTION
* Useful for https://github.com/mlfoundations/datacomp/issues/59 because it's harder to install them otherwise
* Doesn't align with the project's choice of leaving cloud-specific dependencies up to users

https://github.com/mlfoundations/datacomp/blob/fa9d76634647227831de1a385daa13965b46c788/README.md?plain=1#L38